### PR TITLE
Detect Jujutsu repository properly

### DIFF
--- a/mozphab/detect_repository.py
+++ b/mozphab/detect_repository.py
@@ -17,7 +17,7 @@ def find_repo_root(path: str) -> Optional[str]:
     """Lightweight check for a repo in/under the specified path."""
     path = os.path.abspath(path)
     while os.path.split(path)[1]:
-        if Mercurial.is_repo(path) or Git.is_repo(path):
+        if Mercurial.is_repo(path) or Jujutsu.is_repo(path) or Git.is_repo(path):
             return path
         path = os.path.abspath(os.path.join(path, os.path.pardir))
     return None

--- a/mozphab/jujutsu.py
+++ b/mozphab/jujutsu.py
@@ -29,6 +29,11 @@ from .subprocess_wrapper import check_call, check_output
 
 
 class Jujutsu(Repository):
+    @classmethod
+    def is_repo(cls, path: str) -> bool:
+        """Quick check for repository at specified path."""
+        return os.path.exists(os.path.join(path, ".jj"))
+
     # ----
     # Methods expected from callers of the `Repository` interface:
     # ----


### PR DESCRIPTION
Otherwise, `moz-phab` will refuse to run in a directory which does not also contain a colocated `.git` subdirectory.