### PR TITLE
Allow underlying Git repository for Jujutsu to be located somewhere else

### DIFF
--- a/mozphab/detect_repository.py
+++ b/mozphab/detect_repository.py
@@ -17,7 +17,7 @@ def find_repo_root(path: str) -> Optional[str]:
     """Lightweight check for a repo in/under the specified path."""
     path = os.path.abspath(path)
     while os.path.split(path)[1]:
-        if Mercurial.is_repo(path) or Git.is_repo(path):
+        if Mercurial.is_repo(path) or Jujutsu.is_repo(path) or Git.is_repo(path):
             return path
         path = os.path.abspath(os.path.join(path, os.path.pardir))
     return None

--- a/mozphab/jujutsu.py
+++ b/mozphab/jujutsu.py
@@ -29,6 +29,11 @@ from .subprocess_wrapper import check_call, check_output
 
 
 class Jujutsu(Repository):
+    @classmethod
+    def is_repo(cls, path: str) -> bool:
+        """Quick check for repository at specified path."""
+        return os.path.exists(os.path.join(path, ".jj"))
+
     # ----
     # Methods expected from callers of the `Repository` interface:
     # ----


### PR DESCRIPTION
This allows the usage of multiple JJ workspaces, and also allows placing the underlying Git repository outside the JJ repository.